### PR TITLE
Add a handler for undeletable tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.3
+- ignore an error when we try to delete an Intercom tag, which cannot be deleted (error 400)
+
 ## 0.5.2
 - implement logging convention and adjust logging levels
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "tags": ["outgoing", "incoming", "batch", "oneColumn"],
   "admin" : "/auth/",
   "picture": "picture.png",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "settings": [],
   "private_settings":[
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hull-intercom",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Hull Intercom integration",
   "main": "index.js",
   "scripts": {

--- a/server/lib/sync-agent/tag-mapping.js
+++ b/server/lib/sync-agent/tag-mapping.js
@@ -97,6 +97,17 @@ export default class TagMapping {
           _.unset(this.mapping, segment.id);
           return Promise.resolve();
         }
+
+        if (fErr.statusCode === 400) {
+          this.hullAgent.hullClient.logger.error("sync.error", {
+            error: "Unable to delete tag",
+            segment: segment.id,
+            tag_id: tagId
+          });
+          _.unset(this.mapping, segment.id);
+          return Promise.resolve();
+        }
+
         return Promise.reject(fErr);
       });
   }


### PR DESCRIPTION
- ignore an error when we try to delete an Intercom tag, which cannot be deleted (error 400)