### PR TITLE
Fixed require @risingstack/trace which was not loaded as expected

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -35,6 +35,11 @@ const queue = new Queue("kue", {
   prefix: KUE_PREFIX,
   redis: REDIS_URL
 });
+try {
+  queue.adapter.queue.watchStuckJobs();
+} catch (e) {
+  console.error(e);
+}
 
 const connector = new Hull.Connector({ queue, cache, hostSecret: SECRET, port: PORT });
 const app = express();

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,6 @@
 /* @flow */
+require("@risingstack/trace");
+
 import Hull from "hull";
 import { Queue, Cache } from "hull/lib/infra";
 import express from "express";


### PR DESCRIPTION
`-r @risingstack/trace` didn't result in require line as expected, so I moved it back in. Tested it locally and it is running fine now.